### PR TITLE
feat(wai-handler-launch): Add function to launch arbitrary URLs

### DIFF
--- a/wai-handler-launch/ChangeLog.md
+++ b/wai-handler-launch/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.0.3
+
+* Add `runHostPortFullUrl` to allow launching arbitrary URLs [#2](https://github.com/yesodweb/wai-handlers/pull/2)
+
 ## 3.0.2.4
 
 * Drop dependency on blaze-builder, requiring streaming-commons >= 0.2

--- a/wai-handler-launch/wai-handler-launch.cabal
+++ b/wai-handler-launch/wai-handler-launch.cabal
@@ -1,5 +1,5 @@
 Name:                wai-handler-launch
-Version:             3.0.2.5
+Version:             3.0.3
 Synopsis:            Launch a web app in the default browser.
 description:         API docs and the README are available at <http://www.stackage.org/package/wai-handler-launch>.
 License:             MIT

--- a/wai-handler-launch/wai-handler-launch.cabal
+++ b/wai-handler-launch/wai-handler-launch.cabal
@@ -1,5 +1,5 @@
 Name:                wai-handler-launch
-Version:             3.0.2.4
+Version:             3.0.2.5
 Synopsis:            Launch a web app in the default browser.
 description:         API docs and the README are available at <http://www.stackage.org/package/wai-handler-launch>.
 License:             MIT

--- a/wai-handler-launch/windows.c
+++ b/wai-handler-launch/windows.c
@@ -2,11 +2,7 @@
 #include <shellapi.h>
 #include <stdio.h>
 
-void launch(int port, char *s)
+void launch(char *s)
 {
-    int len = 8 + strlen("http://127.0.0.1:") + strlen(s);
-    char *buff = malloc(len);
-    _snprintf(buff, len, "http://127.0.0.1:%d/%s", port, s);
-    ShellExecute(NULL, "open", buff, NULL, NULL, SW_SHOWNORMAL);
-    free(buff);
+    ShellExecute(NULL, "open", s, NULL, NULL, SW_SHOWNORMAL);
 }


### PR DESCRIPTION
This commit adds the function `runHostPortFullUrl` to allow launching
arbitrary URLs instead of the hardcoded base `http://127.0.0.1`.
It allows using `::1` as the host IP address, while launching `http://[::1]/`,
where the additional brackets are required to access IPv6 IPs from the browser.

As the generation of the default URL is moved into `runHostPortUrl`, both the C launch
function and the Haskell launch function can be reduced to (C)String -> IO ()
without breaking backwards compability.

This closes #1

Before submitting your PR, check that you've:

- [X] Bumped the version number
- [X] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [X] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

# Todo

 - [ ] Check for functionality on Windows systems