### PR TITLE
Require Cabal-version 1.8

### DIFF
--- a/wai-handler-launch/wai-handler-launch.cabal
+++ b/wai-handler-launch/wai-handler-launch.cabal
@@ -8,7 +8,7 @@ Author:              Michael Snoyman
 Maintainer:          michael@snoyman.com
 Category:            Web
 Build-type:          Simple
-Cabal-version:       >=1.6
+Cabal-version:       >=1.8
 extra-source-files:  README.md ChangeLog.md
 
 Library


### PR DESCRIPTION
```
Warning: wai-handler-launch.cabal:30:41: version operators used. To use
version operators the package needs to specify at least 'cabal-version: >=
1.8'.
```